### PR TITLE
Feature/634 button external

### DIFF
--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -61,7 +61,7 @@ add_action( 'after_setup_theme', __NAMESPACE__ . '\customize_block_support' );
 function enqueue_block_editor_assets() {
 	wp_enqueue_script(
 		'wds-headless-blocks',
-		WDS_HEADLESS_BLOCKS_PLUGIN_URL . '/js/blocks.js',
+		untrailingslashit( WDS_HEADLESS_BLOCKS_PLUGIN_URL ) . '/js/blocks.js',
 		[ 'wp-blocks', 'wp-element', 'lodash' ],
 		WDS_HEADLESS_BLOCKS_VERSION,
 		true

--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -72,7 +72,7 @@ function enqueue_block_editor_assets() {
 		return;
 	}
 
-	// Add FE URL to blocks script.
-	wp_add_inline_script( 'wds-headless-blocks', 'const frontendUrl = "' . untrailingslashit( HEADLESS_FRONTEND_URL ) . '"', 'before' );
+	// Add FE & BE URLs to blocks script.
+	wp_add_inline_script( 'wds-headless-blocks', 'const frontendUrl = "' . untrailingslashit( HEADLESS_FRONTEND_URL ) . '"; const backendUrl = "' . untrailingslashit( site_url() ) . '";', 'before' );
 }
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_block_editor_assets' );

--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -66,5 +66,13 @@ function enqueue_block_editor_assets() {
 		WDS_HEADLESS_BLOCKS_VERSION,
 		true
 	);
+
+
+	if ( ! defined( 'HEADLESS_FRONTEND_URL' ) ) {
+		return;
+	}
+
+	// Add FE URL to blocks script.
+	wp_add_inline_script( 'wds-headless-blocks', 'const frontendUrl = "' . untrailingslashit( HEADLESS_FRONTEND_URL ) . '"', 'before' );
 }
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_block_editor_assets' );

--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -67,7 +67,6 @@ function enqueue_block_editor_assets() {
 		true
 	);
 
-
 	if ( ! defined( 'HEADLESS_FRONTEND_URL' ) ) {
 		return;
 	}

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -255,6 +255,6 @@ const withButtonAttrs = createHigherOrderComponent((BlockEdit) => {
 
     return createElement(BlockEdit, props)
   }
-}, 'withColorPaletteHexValues')
+}, 'withButtonAttrs')
 
 addFilter('editor.BlockEdit', 'wds/filterBlockEditButtonAttrs', withButtonAttrs)

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -227,3 +227,34 @@ addFilter(
   'wds/filterButtonAttrs',
   wdsUpdateButtonAtrrs
 )
+
+/**
+ * Filter block edit function to set custom button attributes.
+ *
+ * @author WebDevStudios
+ * @since NEXT
+ */
+const withButtonAttrs = createHigherOrderComponent((BlockEdit) => {
+  return (props) => {
+    const {
+      attributes: {url},
+      name
+    } = props
+
+    useEffect(() => {
+      if (name !== 'core/button' || !url) {
+        return
+      }
+
+      // Determine value of urlExternal by comparing url to FE/BE URLs.
+      const hasFrontendUrl = frontendUrl ? url.indexOf(frontendUrl) >= 0 : false
+      const hasBackendUrl = backendUrl ? url.indexOf(backendUrl) >= 0 : false
+
+      props.attributes.urlExternal = !hasFrontendUrl && !hasBackendUrl
+    }, [name, url])
+
+    return createElement(BlockEdit, props)
+  }
+}, 'withColorPaletteHexValues')
+
+addFilter('editor.BlockEdit', 'wds/filterBlockEditButtonAttrs', withButtonAttrs)

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -5,7 +5,7 @@
  * @since 1.0.0
  */
 
-/* global wp, lodash */
+/* global wp, lodash, frontendUrl, backendUrl */
 const {validateThemeColors, validateThemeGradients} = wp.blockEditor
 const {useEffect, createElement} = wp.element
 const {addFilter} = wp.hooks
@@ -194,4 +194,36 @@ addFilter(
   'editor.BlockEdit',
   'wds/filterBlockEditColorAttrs',
   withColorPaletteHexValues
+)
+
+/**
+ * Filter block registration to add custom attributes to button block.
+ *
+ * @author WebDevStudios
+ * @since NEXT
+ * @param  {object} settings Block settings config.
+ * @return {object}          Block settings config.
+ */
+function wdsUpdateButtonAtrrs(settings) {
+  if (settings.name !== 'core/button') {
+    return settings
+  }
+
+  const attributes = {}
+
+  // Add urlExternal attribute.
+  attributes.urlExternal = {
+    type: 'boolean',
+    default: false
+  }
+
+  return assign({}, settings, {
+    attributes: assign({}, settings.attributes, attributes)
+  })
+}
+
+addFilter(
+  'blocks.registerBlockType',
+  'wds/filterButtonAttrs',
+  wdsUpdateButtonAtrrs
 )


### PR DESCRIPTION
Relates to https://github.com/WebDevStudios/nextjs-wordpress-starter/issues/634 (will require FE PR to handle new attr)

Adds new `urlExternal` attribute to core button block, set to true when button URL does not contain either frontend or backend domains.